### PR TITLE
fix(read-articles): Fix read all articles retrieve

### DIFF
--- a/src/app/__tests__/articles/articlesActions.test.js
+++ b/src/app/__tests__/articles/articlesActions.test.js
@@ -20,11 +20,9 @@ describe('fetch articles', () => {
     const response = {
       data: {
         article: {
-          results: {
-            id: 1,
-            body: 'Test',
-            description: 'Test'
-          }
+          id: 1,
+          body: 'Test',
+          description: 'Test'
         }
       }
     }
@@ -32,7 +30,7 @@ describe('fetch articles', () => {
     const expectedActions = [
       {
         type: articlesTypes.FETCH_ARTICLES,
-        payload: response.data.article.results
+        payload: response.data.article
       }
     ];
     moxios.wait(() => {

--- a/src/app/components/articles/ArticlesComponent.jsx
+++ b/src/app/components/articles/ArticlesComponent.jsx
@@ -24,6 +24,7 @@ const ArticlesComponent = (props) => {
         </div></div></Link>));
   return (<div><div className="container">
     <h2 className="articles-heading">Recent Articles</h2><hr />
-    <div className="row">{articlesItems}</div></div></div>);
+    <div className="row">{articlesItems}</div></div></div>
+  );
 };
 export default ArticlesComponent;

--- a/src/redux/actions/articles/ArticlesActions.js
+++ b/src/redux/actions/articles/ArticlesActions.js
@@ -11,7 +11,7 @@ const fetchArticles = () => dispatch => {
     .then(response => {
       dispatch({
         type: articlesTypes.FETCH_ARTICLES,
-        payload: response.data.article.results
+        payload: response.data.article
       });
     });
 };


### PR DESCRIPTION
#### What does this PR do?
Fixes the read all articles functionality after changes made in the backend pagination manipulation.
#### Description of Task to be completed
- Drop `.results` in the articles actions response.
#### How should this be manually tested?
N/A
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#166764081](https://www.pivotaltracker.com/story/show/166764081)
#### Screenshots (if appropriate)
N/A

